### PR TITLE
Move out auth Login calls to authentication module

### DIFF
--- a/src/components/welcomeView/LoginModal.jsx
+++ b/src/components/welcomeView/LoginModal.jsx
@@ -4,9 +4,9 @@ import { ToastContainer, toast } from "react-toastify";
 import { Box, TextField, Modal, Button } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
 import { useTranslation } from "react-i18next";
-import auth from "../../modules/auth";
-import welcomePageStyle from '../../theme/welcomePage'
-
+// import auth from "../../modules/auth";
+import Authentication from "../../modules/auth";
+import welcomePageStyle from "../../theme/welcomePage";
 
 const LoginModal = () => {
   const dispatch = useDispatch();
@@ -17,22 +17,23 @@ const LoginModal = () => {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-    const form = event.target;
-    const email = form.email.value;
-    const password = form.password.value;
-    try {
-      const response = await auth.signIn(email, password);
-      setLoading(true);
-      toast.success(t("loginSuccess"), {
-        onClose: () =>
-          dispatch({
-            type: "SET_CURRENT_USER",
-            payload: response.data,
-          }),
-      });
-    } catch (error) {
-      toast.error(error.response.data.errors[0]);
-    }
+    Authentication.signIn(event.target);
+    // const form = event.target;
+    // const email = form.email.value;
+    // const password = form.password.value;
+    // try {
+    //   const response = await auth.signIn(email, password);
+    //   setLoading(true);
+    //   toast.success(t("loginSuccess"), {
+    //     onClose: () =>
+    //       dispatch({
+    //         type: "SET_CURRENT_USER",
+    //         payload: response.data,
+    //       }),
+    //   });
+    // } catch (error) {
+    //   toast.error(error.response.data.errors[0]);
+    // }
   };
 
   return (
@@ -57,7 +58,7 @@ const LoginModal = () => {
         onClose={() => setOpen(false)}
         aria-labelledby="modal-modal-title"
       >
-        <Box  noValidate autoComplete="on" className={classes.loginBox}>
+        <Box noValidate autoComplete="on" className={classes.loginBox}>
           <form onSubmit={handleSubmit} data-cy="sign-in-form">
             <TextField
               className={classes.inputLogin}
@@ -85,7 +86,7 @@ const LoginModal = () => {
               sx={{
                 m: 2,
                 backgroundColor: "#4C9074",
-                color: "#D6BC01"
+                color: "#D6BC01",
               }}
             >
               {t("login")}

--- a/src/components/welcomeView/LoginModal.jsx
+++ b/src/components/welcomeView/LoginModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
-import { ToastContainer, toast } from "react-toastify";
+import { ToastContainer } from "react-toastify";
 import { Box, TextField, Modal, Button } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
 import { useTranslation } from "react-i18next";
@@ -8,7 +7,6 @@ import Authentication from "../../modules/auth";
 import welcomePageStyle from "../../theme/welcomePage";
 
 const LoginModal = () => {
-  const dispatch = useDispatch();
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);

--- a/src/components/welcomeView/LoginModal.jsx
+++ b/src/components/welcomeView/LoginModal.jsx
@@ -4,7 +4,6 @@ import { ToastContainer, toast } from "react-toastify";
 import { Box, TextField, Modal, Button } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
 import { useTranslation } from "react-i18next";
-// import auth from "../../modules/auth";
 import Authentication from "../../modules/auth";
 import welcomePageStyle from "../../theme/welcomePage";
 
@@ -16,24 +15,10 @@ const LoginModal = () => {
   const classes = welcomePageStyle();
 
   const handleSubmit = async (event) => {
+    setLoading(true);
     event.preventDefault();
-    Authentication.signIn(event.target);
-    // const form = event.target;
-    // const email = form.email.value;
-    // const password = form.password.value;
-    // try {
-    //   const response = await auth.signIn(email, password);
-    //   setLoading(true);
-    //   toast.success(t("loginSuccess"), {
-    //     onClose: () =>
-    //       dispatch({
-    //         type: "SET_CURRENT_USER",
-    //         payload: response.data,
-    //       }),
-    //   });
-    // } catch (error) {
-    //   toast.error(error.response.data.errors[0]);
-    // }
+    Authentication.signIn(event.target, t("loginSuccess"));
+    setLoading(false);
   };
 
   return (

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -1,8 +1,6 @@
 import store from "../state/store/configureStore";
 import JtockAuth from "j-tockauth";
-// import axios from "axios";
 import { toast } from "react-toastify";
-import { useTranslation } from "react-i18next";
 
 let url = "";
 if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
@@ -33,5 +31,3 @@ const Authentication = {
 };
 
 export default Authentication;
-
-// export default auth;

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -1,4 +1,8 @@
+import store from "../state/store/configureStore";
 import JtockAuth from "j-tockauth";
+// import axios from "axios";
+import { toast } from "react-toastify";
+import { useTranslation } from "react-i18next";
 
 let url = "";
 if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
@@ -11,4 +15,25 @@ const auth = new JtockAuth({
   prefixUrl: "/api",
 });
 
-export default auth;
+
+
+const Authentication = {
+  async signIn(data) {
+    try {
+      let response = await auth.signIn(data.email.value, data.password.value);
+      toast.success("it worked", {
+        onClose: () =>
+          store.dispatch({
+            type: "SET_CURRENT_USER",
+            payload: response.data,
+          }),
+      });
+    } catch (error) {
+      toast.error(error.response.data.errors[0]);
+    }
+  },
+};
+
+export default Authentication;
+
+// export default auth;

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -15,13 +15,11 @@ const auth = new JtockAuth({
   prefixUrl: "/api",
 });
 
-
-
 const Authentication = {
-  async signIn(data) {
+  async signIn(data, loginSuccessMessage) {
     try {
       let response = await auth.signIn(data.email.value, data.password.value);
-      toast.success("it worked", {
+      toast.success(loginSuccessMessage, {
         onClose: () =>
           store.dispatch({
             type: "SET_CURRENT_USER",


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/180407728

### User Story
```
As an admin client
In order for my code to be more readible
I would like to handle the try/catch in my auth module
```

### Changes Proposed:
- Move try/catch from `LoginModal.jsx` to `auth.js` module
- Pass along the translated message with the login data to keep translation in the React Component

