### PR TITLE
Remove upperCase in URL routes

### DIFF
--- a/cypress/integration/userCanSeeListOfParticipants.feature.js
+++ b/cypress/integration/userCanSeeListOfParticipants.feature.js
@@ -43,6 +43,13 @@ describe("Admin can see a list of departments", () => {
         .children()
         .should("have.length", 2);
     });
+
+    it.only("is expected that the URL path is rendered in lowercase", () => {
+      cy.get("[data-cy=department-table]").within(() => {
+        cy.contains("Management").click();
+        cy.url().should("contain", "management");
+      });
+    });
   });
 
   describe("unsuccessfully", () => {

--- a/cypress/integration/userCanSeeListOfParticipants.feature.js
+++ b/cypress/integration/userCanSeeListOfParticipants.feature.js
@@ -44,7 +44,7 @@ describe("Admin can see a list of departments", () => {
         .should("have.length", 2);
     });
 
-    it.only("is expected that the URL path is rendered in lowercase", () => {
+    it("is expected that the URL path is rendered in lowercase", () => {
       cy.get("[data-cy=department-table]").within(() => {
         cy.contains("Management").click();
         cy.url().should("contain", "management");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import theme from "../src/theme/theme";
 const App = () => {
   const { authenticated, participantList } = useSelector((state) => state);
 
-  let departmentUrl = `/departments/${participantList.department}`;
+  let departmentUrl = `/departments/${participantList.department?.toLowerCase()}`;
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/components/Departments.jsx
+++ b/src/components/Departments.jsx
@@ -33,7 +33,7 @@ const Departments = () => {
       cellClassName: "super-app-theme--cell",
       renderCell: (params) => (
         <Link
-          to={`/departments/${params.value}`}
+          to={`/departments/${params.value.toLowerCase()}`}
           style={{ color: "inherit", textDecoration: "inherit" }}
           onClick={() => {
             dispatch({


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/180425203

### User Story
```
As a frontend client
In order to not dilute SEO rankings
I would like all my urls to be rendered in lower case
```

### Changes Proposed
- Add test for when user clicks through to participants
- Add `toLowerCase` in `App.jsx` and `Departments.jsx`